### PR TITLE
Update MATSim version to 2025w31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 		<groupId>org.matsim</groupId>
 		<artifactId>matsim-all</artifactId>
 <!--		<version>2026.0-PR3957</version>-->
-		<version>2026.0-2025w30</version>
+		<version>2026.0-2025w31</version>
 <!--        <version>2026.0-SNAPSHOT</version>-->
 	</parent>
 


### PR DESCRIPTION
Doing this manually, because on monday the weekly build was not available.